### PR TITLE
remove 16 parameter popup

### DIFF
--- a/Scripts/AvaCryptController.cs
+++ b/Scripts/AvaCryptController.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Linq;
 using UnityEditor;
@@ -119,13 +119,6 @@ namespace GeoTetra.GTAvaCrypt
                 {
                     Debug.Log($"Parameter already added: {keyName}");
                 }
-            }
-
-            if (controller.parameters.Length > 16)
-            {
-                EditorUtility.DisplayDialog("More than 16 Parameters on Controller.", 
-                    "VRChat only supports 16 custom parameters, and more than 16 were detected on this controller, which means you probably need to delete some.", 
-                    "Ok");
             }
         }
 


### PR DESCRIPTION
VRChat no longer uses a limit of 16, so this can safely be removed (and likely replaced in the future).